### PR TITLE
Add option to select existing local traffic policy

### DIFF
--- a/templates/bigip-fast-templates/_local_traffic_policy.yaml
+++ b/templates/bigip-fast-templates/_local_traffic_policy.yaml
@@ -1,0 +1,25 @@
+contentType: application/json
+bigipHideTemplate: true
+definitions:
+  enable_local_traffic_policy:
+    title: Local Traffic Policy
+    description: Enable Local Traffic Policy to enforce appropriate access controls
+    type: boolean
+    default: true
+  local_traffic_policy_name:
+    title: Local Traffic Policy
+    description: Select an existing Local Traffic Policy. *Draft* policies are not permitted.
+    enumFromBigip: ltm/policy
+    default: ""
+template: |
+  {
+    "{{tenant_name}}": {
+      "{{app_name}}": {
+        {{#enable_local_traffic_policy}}
+        "{{app_name}}": {
+          "policyEndpoint": { "bigip": "{{local_traffic_policy_name}}" }
+        }
+        {{/enable_local_traffic_policy}}
+      }
+    }
+  }

--- a/templates/bigip-fast-templates/http_with_traffic_policy.yaml
+++ b/templates/bigip-fast-templates/http_with_traffic_policy.yaml
@@ -1,0 +1,21 @@
+contentType: application/json
+title: HTTP Application Template
+description: Configure high availability and optimization for HTTP and HTTPS implementations.
+allOf:
+  - $ref: "_as3.yaml#"
+  - $ref: "_virtual.yaml#"
+  - $ref: "_redirect_http.yaml#"
+  - $ref: "_snat.yaml#"
+  - $ref: "_persist.yaml#"
+  - $ref: "_tls_server_profile.yaml#"
+  - $ref: "_tls_client_profile.yaml#"
+  - $ref: "_pool.yaml#"
+  - $ref: "_monitor_http.yaml#"
+  - $ref: "_http_profile.yaml#"
+  - $ref: "_tcp_profile.yaml#"
+  - $ref: "_irule.yaml#"
+  - $ref: "_local_traffic_policy.yaml"
+anyOf:
+  - {}
+  - $ref: "_firewall.yaml#"
+template: ""


### PR DESCRIPTION
Need to provide an option for selecting an existing local traffic policy when deploying HTTP applications via templates, otherwise, the big-ip administrator needs to manually edit the resulting virtual server in order to attach the desired local traffic policy.