### PR TITLE
Update microsoft_exchange.yaml

### DIFF
--- a/templates/bigip-fast-templates/microsoft_exchange.yaml
+++ b/templates/bigip-fast-templates/microsoft_exchange.yaml
@@ -952,7 +952,7 @@ definitions:
           {{/make_snatpool}}
           {{^make_snatpool}}
             "snat": {
-              "bigip": { "bigip": "{{snatpool_name:f5:bigip_path}}" }
+              "bigip": "{{snatpool_name:f5:bigip_path}}"
             },
           {{/make_snatpool}}
         {{/snat_automap}}


### PR DESCRIPTION
A bug with repeat "bigip" for existing SNAT Pool configuration. Line 955.
Tested and it now works. Otherwise creates an error similar to this:
 "undefined /Test/Exchange2016/Exchange2016_imap4_vs/snat/bigip: should be string".



Cheers,
Igor Koudashev
i.koudashev@f5.com